### PR TITLE
Userモデルの分割とidの最小値設定

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -56,6 +56,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseUser'
+              examples:
+                example:
+                  value:
+                    id: 1
+                    name: putuser
+                    created_at: '2019-08-24T14:15:22Z'
+                    updated_at: '2019-08-24T14:15:22Z'
         '400':
           description: Bad Request
         '500':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16,7 +16,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/ResponseUser'
               examples:
                 example:
                   value:
@@ -55,7 +55,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/ResponseUser'
         '400':
           description: Bad Request
         '500':
@@ -66,7 +66,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/User'
+              $ref: '#/components/schemas/RequestUser'
             examples:
               example:
                 value:
@@ -84,7 +84,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/User'
+                  $ref: '#/components/schemas/ResponseUser'
               examples:
                 example:
                   value:
@@ -111,7 +111,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/ResponseUser'
               examples:
                 example:
                   value:
@@ -127,7 +127,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/User'
+              $ref: '#/components/schemas/RequestUser'
             examples:
               example:
                 value:
@@ -136,16 +136,21 @@ paths:
         - user
 components:
   schemas:
-    User:
-      title: User
+    RequestUser:
+      title: RequestUser
       type: object
-      description: ''
+      properties:
+        name:
+          type: string
+          minLength: 1
+      required:
+        - name
       x-examples:
         example:
-          id: 42
-          name: nop
-          created_at: '2021-01-01T12:42:42Z'
-          updated_at: '2042-01-01T12:42:42Z'
+          name: username
+    ResponseUser:
+      title: ResponseUser
+      type: object
       properties:
         id:
           type: integer
@@ -157,16 +162,20 @@ components:
         created_at:
           type: string
           format: date-time
-          readOnly: true
         updated_at:
           type: string
           format: date-time
-          readOnly: true
       required:
         - id
         - name
         - created_at
         - updated_at
+      x-examples:
+        example:
+          id: 42
+          name: nop
+          created_at: '2021-01-01T12:42:42Z'
+          updated_at: '2042-01-01T12:42:42Z'
   requestBodies: {}
   responses: {}
   parameters:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20,7 +20,7 @@ paths:
               examples:
                 example:
                   value:
-                    id: 0
+                    id: 1
                     name: getuser
                     created_at: '2019-08-24T14:15:22Z'
                     updated_at: '2019-08-24T14:15:22Z'
@@ -88,11 +88,11 @@ paths:
               examples:
                 example:
                   value:
-                    - id: 0
+                    - id: 1
                       name: name1
                       created_at: '2019-08-24T14:15:22Z'
                       updated_at: '2019-08-24T14:15:22Z'
-                    - id: 1
+                    - id: 2
                       name: name2
                       created_at: '2019-08-25T14:15:22Z'
                       updated_at: '2019-08-25T14:15:22Z'
@@ -115,7 +115,7 @@ paths:
               examples:
                 example:
                   value:
-                    id: 0
+                    id: 1
                     name: postuser
                     created_at: '2019-08-24T14:15:22Z'
                     updated_at: '2019-08-24T14:15:22Z'
@@ -155,7 +155,7 @@ components:
         id:
           type: integer
           description: Unique identifier for the given user.
-          readOnly: true
+          minimum: 1
         name:
           type: string
           minLength: 1


### PR DESCRIPTION
Fix #3 #4

## やったこと
- UserモデルをRequestUserとResponseUserに分けました。
- ResponseUser.idの最小値を1以上に設定しました。
  - これに伴い、id: 0となっていたexampleも修正しています。
- PUT /users/{userId} のexampleが無かったので追加しました。