### PR TITLE
Session oauth

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -61,7 +61,6 @@ paths:
                 $ref: '#/components/schemas/Error'
       operationId: get-users
       description: ''
-      parameters: []
     post:
       summary: Create new user
       operationId: post-users
@@ -125,9 +124,7 @@ paths:
                   status_message: bow-wow!
       tags:
         - user
-      parameters: []
   /me:
-    parameters: []
     get:
       summary: Get User Info by User ID
       responses:
@@ -164,7 +161,6 @@ paths:
       description: Retrieve the information of the user with the matching user ID.
       tags:
         - user
-      parameters: []
   '/users/by/{username}':
     parameters:
       - $ref: '#/components/parameters/username'
@@ -204,7 +200,6 @@ paths:
                 $ref: '#/components/schemas/Error'
       operationId: get-users-username
       description: ''
-      parameters: []
   '/users/{userID}':
     parameters:
       - $ref: '#/components/parameters/userId'
@@ -244,7 +239,6 @@ paths:
       description: Retrieve the information of the user with the matching user ID.
       tags:
         - user
-      parameters: []
     delete:
       summary: Delete User
       operationId: delete-users-userId
@@ -271,7 +265,6 @@ paths:
                 $ref: '#/components/schemas/Error'
       tags:
         - user
-      parameters: []
     put:
       summary: Update User Information
       operationId: put-users-userId
@@ -330,7 +323,6 @@ paths:
                   username: inu
                   display_name: 犬
                   status_message: bow-wow!
-      parameters: []
   '/users/{userID}/friends':
     parameters:
       - $ref: '#/components/parameters/userId'
@@ -396,7 +388,6 @@ paths:
       tags:
         - auth
       operationId: get-auth-login
-      parameters: []
       responses:
         '307':
           description: Temporary Redirect
@@ -409,7 +400,6 @@ paths:
         The first client request by 42 for oauth2.0.
         After this, you will be redirected to 42's login page.
       security: []
-    parameters: []
   /auth/callback/42:
     get:
       summary: Your GET endpoint
@@ -432,9 +422,7 @@ paths:
       description: |-
         After allowing transcendence on screen 42, you will be redirected here.
         This is where the server-side will register or retrieve the user's information.
-      parameters: []
       security: []
-    parameters: []
 components:
   schemas:
     RequestUser:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -84,6 +84,11 @@ paths:
                     status_message: ほげほげ
                     created_at: '2019-08-24T14:15:22Z'
                     updated_at: '2019-08-24T14:15:22Z'
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+              description: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
         '400':
           description: Bad Request
           content:
@@ -397,15 +402,15 @@ paths:
       summary: Your GET endpoint
       tags: []
       operationId: get-auth-login
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: Location
-          description: login url of 42
+      parameters: []
       responses:
         '307':
           description: Temporary Redirect
+          headers:
+            Location:
+              schema:
+                type: string
+              description: login url of 42
       description: |-
         The first client request by 42 for oauth2.0.
         After this, you will be redirected to 42's login page.
@@ -414,7 +419,18 @@ paths:
     get:
       summary: Your GET endpoint
       tags: []
-      responses: {}
+      responses:
+        '307':
+          description: Temporary Redirect
+          headers:
+            Location:
+              schema:
+                type: string
+              description: to the home
+            Set-Cookie:
+              schema:
+                type: string
+              description: like SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
       operationId: get-auth-callback
       description: |-
         After allowing transcendence on screen 42, you will be redirected here.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   title: openapi
   version: '1.0'
+  description: ''
 servers:
   - url: 'http://localhost:4211'
 paths:
@@ -60,6 +61,8 @@ paths:
                 $ref: '#/components/schemas/Error'
       operationId: get-users
       description: ''
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
     post:
       summary: Create new user
       operationId: post-users
@@ -117,6 +120,8 @@ paths:
                   status_message: bow-wow!
       tags:
         - user
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
   /me:
     parameters: []
     get:
@@ -155,6 +160,8 @@ paths:
       description: Retrieve the information of the user with the matching user ID.
       tags:
         - user
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
   '/users/by/{username}':
     parameters:
       - $ref: '#/components/parameters/username'
@@ -194,6 +201,8 @@ paths:
                 $ref: '#/components/schemas/Error'
       operationId: get-users-username
       description: ''
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
   '/users/{userID}':
     parameters:
       - $ref: '#/components/parameters/userId'
@@ -233,6 +242,8 @@ paths:
       description: Retrieve the information of the user with the matching user ID.
       tags:
         - user
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
     delete:
       summary: Delete User
       operationId: delete-users-userId
@@ -259,6 +270,8 @@ paths:
                 $ref: '#/components/schemas/Error'
       tags:
         - user
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
     put:
       summary: Update User Information
       operationId: put-users-userId
@@ -317,6 +330,8 @@ paths:
                   username: inu
                   display_name: 犬
                   status_message: bow-wow!
+      parameters:
+        - $ref: '#/components/parameters/sessionId'
   '/users/{userID}/friends':
     parameters:
       - $ref: '#/components/parameters/userId'
@@ -376,6 +391,39 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/sessionId'
+  /auth/login/42:
+    get:
+      summary: Your GET endpoint
+      tags: []
+      operationId: get-auth-login
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Location
+          description: login url of 42
+      responses:
+        '307':
+          description: Temporary Redirect
+      description: |-
+        The first client request by 42 for oauth2.0.
+        After this, you will be redirected to 42's login page.
+    parameters: []
+  /auth/callback/42:
+    get:
+      summary: Your GET endpoint
+      tags: []
+      responses: {}
+      operationId: get-auth-callback
+      description: |-
+        After allowing transcendence on screen 42, you will be redirected here.
+        This is where the server-side will register or retrieve the user's information.
+      parameters:
+        - schema:
+            type: string
+          in: query
+    parameters: []
 components:
   schemas:
     RequestUser:
@@ -484,4 +532,11 @@ components:
       schema:
         type: integer
         minimum: 0
+    sessionId:
+      name: sessionId
+      in: cookie
+      required: true
+      schema:
+        type: string
   examples: {}
+  securitySchemes: {}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -395,33 +395,15 @@ paths:
             Location:
               schema:
                 type: string
-              description: login url of 42
-      description: |-
-        The first client request by 42 for oauth2.0.
-        After this, you will be redirected to 42's login page.
-      security: []
-  /auth/callback/42:
-    get:
-      summary: Your GET endpoint
-      tags:
-        - auth
-      responses:
-        '307':
-          description: Temporary Redirect
-          headers:
-            Location:
-              schema:
-                type: string
               description: to the home
             Set-Cookie:
               schema:
                 type: string
                 example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
-              description: set sessionId
-      operationId: get-auth-callback
+              description: set sessionId in cookie
       description: |-
-        After allowing transcendence on screen 42, you will be redirected here.
-        This is where the server-side will register or retrieve the user's information.
+        The first client request by 42 for oauth2.0.
+        After this, you will be redirected to 42's login page.
       security: []
 components:
   schemas:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -390,13 +390,14 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
-  '/auth/login/{provider}':
+  /auth/login:
     get:
       summary: Your GET endpoint
       tags:
         - auth
       operationId: get-auth-login
-      parameters: []
+      parameters:
+        - $ref: '#/components/parameters/provider'
       responses:
         '307':
           description: Temporary Redirect
@@ -404,12 +405,37 @@ paths:
             Location:
               schema:
                 type: string
-              description: login url of 42
+              description: browser confirm of 42
       description: |-
         The first client request by 42 for oauth2.0.
-        After this, you will be redirected to 42's login page.
+        After this, you will be redirected to 42's confirm browser.
       security: []
-  /auth/callback/42:
+    parameters: []
+    post:
+      summary: ''
+      operationId: post-auth-login
+      responses:
+        '307':
+          description: Temporary Redirect
+          headers:
+            Location:
+              schema:
+                type: string
+              description: to the home
+            Set-Cookie:
+              schema:
+                type: string
+                example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
+              description: set sessionId
+      description: username and password auth without using auth.
+      parameters: []
+      security: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+  /auth/callback:
     get:
       summary: Your GET endpoint
       tags:
@@ -432,12 +458,7 @@ paths:
         After allowing transcendence on screen 42, you will be redirected here.
         This is where the server-side will register or retrieve the user's information.
       security: []
-    parameters:
-      - schema:
-          type: string
-        name: provider
-        in: path
-        required: true
+    parameters: []
 components:
   schemas:
     RequestUser:
@@ -546,6 +567,12 @@ components:
       schema:
         type: integer
         minimum: 0
+    provider:
+      name: provider
+      in: query
+      required: true
+      schema:
+        type: string
   examples: {}
   securitySchemes:
     sessionAuth:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -333,9 +333,9 @@ paths:
                   username: inu
                   display_name: 犬
                   status_message: bow-wow!
-  '/auth/login':
+  /auth/login:
     get:
-      summary: Your GET endpoint
+      summary: Oauth login request
       tags:
         - auth
       operationId: get-auth-login
@@ -355,7 +355,7 @@ paths:
       security: []
     parameters: []
     post:
-      summary: ''
+      summary: username and password login
       operationId: post-auth-login
       responses:
         '307':
@@ -377,30 +377,17 @@ paths:
         content:
           application/json:
             schema:
-              description: ''
-              type: object
-              properties:
-                username:
-                  type: string
-                  minLength: 1
-                password:
-                  type: string
-                  minLength: 1
-              required:
-                - username
-                - password
-              x-examples:
-                example-1:
-                  username: syudai
-                  password: magiimine
+              $ref: '#/components/schemas/SimpleLoginUser'
             examples:
               example-1:
                 value:
                   username: syudai
                   password: password
-  '/auth/callback':
+      tags:
+        - auth
+  /auth/callback:
     get:
-      summary: Your GET endpoint
+      summary: Oauth callback
       tags:
         - auth
       responses:
@@ -696,6 +683,20 @@ components:
           type: integer
         mesasge:
           type: string
+    SimpleLoginUser:
+      description: ''
+      type: object
+      x-examples:
+        example-1:
+          username: syudai
+          password: abc
+      properties:
+        username:
+          type: string
+          minLength: 1
+        password:
+          type: string
+          minLength: 1
   requestBodies: {}
   responses: {}
   parameters:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -54,6 +54,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
         '500':
           description: Internal Server Error
           content:
@@ -98,6 +100,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
         '409':
           description: Conflict
           content:
@@ -157,6 +161,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
         '500':
           description: Internal Server Error
           content:
@@ -193,6 +199,8 @@ paths:
                     status_message: ほげほげ
                     created_at: '2019-08-24T14:15:22Z'
                     updated_at: '2019-08-24T14:15:22Z'
+        '401':
+          description: Unauthorized
         '404':
           description: Not Found
           content:
@@ -231,6 +239,8 @@ paths:
                     status_message: ほげほげ
                     created_at: '2019-08-24T14:15:22Z'
                     updated_at: '2019-08-24T14:15:22Z'
+        '401':
+          description: Unauthorized
         '404':
           description: Not Found
           content:
@@ -260,6 +270,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
         '404':
           description: Not Found
           content:
@@ -302,6 +314,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
         '404':
           description: Not Found
           content:
@@ -471,6 +485,8 @@ paths:
                       status_message: I'm pheasant
                       created_at: '2019-08-24T14:15:22Z'
                       updated_at: '2019-08-24T14:15:22Z'
+        '401':
+          description: Unauthorized
         '404':
           description: Not Found
           content:
@@ -536,6 +552,8 @@ paths:
                       following: 10
                       created_at: '2019-08-24T14:15:22Z'
                       updated_at: '2019-08-24T14:15:22Z'
+        '401':
+          description: Unauthorized
         '404':
           description: Not Found
           content:
@@ -562,6 +580,8 @@ paths:
       responses:
         '204':
           description: No Content
+        '401':
+          description: Unauthorized
         '404':
           description: Not Found
           content:
@@ -582,6 +602,8 @@ paths:
       responses:
         '204':
           description: No Content
+        '401':
+          description: Unauthorized
         '404':
           description: Not Found
           content:
@@ -607,6 +629,8 @@ paths:
       responses:
         '204':
           description: No Content
+        '401':
+          description: Unauthorized
         '404':
           description: Not Found
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -404,15 +404,33 @@ paths:
             Location:
               schema:
                 type: string
+              description: login url of 42
+      description: |-
+        The first client request by 42 for oauth2.0.
+        After this, you will be redirected to 42's login page.
+      security: []
+  /auth/callback/42:
+    get:
+      summary: Your GET endpoint
+      tags:
+        - auth
+      responses:
+        '307':
+          description: Temporary Redirect
+          headers:
+            Location:
+              schema:
+                type: string
               description: to the home
             Set-Cookie:
               schema:
                 type: string
                 example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
-              description: set sessionId in cookie
+              description: set sessionId
+      operationId: get-auth-callback
       description: |-
-        The first client request by provider for oauth2.0.
-        After this, you will be redirected to provider's login page.
+        After allowing transcendence on screen 42, you will be redirected here.
+        This is where the server-side will register or retrieve the user's information.
       security: []
     parameters:
       - schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -392,6 +392,10 @@ paths:
               description: redirect to 42's confirm browser
         '500':
           description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       description: |-
         The first client request by 42 for oauth2.0.
         After this, you will be redirected to 42's confirm browser.
@@ -415,8 +419,16 @@ paths:
               description: set sessionId
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       description: username and password auth without using auth.
       parameters: []
       security: []
@@ -467,6 +479,10 @@ paths:
               description: set sessionId
         '500':
           description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       operationId: get-auth-callback
       description: |-
         After allowing transcendence on screen 42, you will be redirected here.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -437,10 +437,7 @@ paths:
       description: |-
         After allowing transcendence on screen 42, you will be redirected here.
         This is where the server-side will register or retrieve the user's information.
-      parameters:
-        - schema:
-            type: string
-          in: query
+      parameters: []
     parameters: []
 components:
   schemas:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,14 +1,15 @@
 openapi: 3.0.0
 info:
-  title: openapi
+  title: transcendence API
   version: '1.0'
-  description: ''
+  description: The transendence API enables programmatic access to transcendence.
 servers:
   - url: 'http://localhost:4211'
+    description: Local
 paths:
   /users:
     get:
-      summary: Get all users
+      summary: List users
       tags:
         - user
       responses:
@@ -61,7 +62,9 @@ paths:
                 $ref: '#/components/schemas/Error'
       operationId: get-users
       description: ''
-      parameters: []
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
     post:
       summary: Create new user
       operationId: post-users
@@ -129,7 +132,7 @@ paths:
   /me:
     parameters: []
     get:
-      summary: Get User Info by User ID
+      summary: Get the authenticated user
       responses:
         '200':
           description: User Found
@@ -169,7 +172,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/username'
     get:
-      summary: Get User Info by username
+      summary: Get a user by username
       tags:
         - user
       responses:
@@ -209,7 +212,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/userId'
     get:
-      summary: Get User Info by User ID
+      summary: Get a user
       responses:
         '200':
           description: OK
@@ -246,11 +249,11 @@ paths:
         - user
       parameters: []
     delete:
-      summary: Delete User
+      summary: Delete a user
       operationId: delete-users-userId
       responses:
-        '200':
-          description: OK
+        '204':
+          description: No Content
         '400':
           description: Bad Request
           content:
@@ -273,7 +276,7 @@ paths:
         - user
       parameters: []
     put:
-      summary: Update User Information
+      summary: Update a user
       operationId: put-users-userId
       responses:
         '200':
@@ -330,67 +333,7 @@ paths:
                   username: inu
                   display_name: 犬
                   status_message: bow-wow!
-      parameters: []
-  '/users/{userID}/friends':
-    parameters:
-      - $ref: '#/components/parameters/userId'
-    get:
-      summary: Get Friend List of Specified User
-      tags:
-        - user
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ResponseUser'
-              examples:
-                example:
-                  value:
-                    - id: 2
-                      username: inu
-                      display_name: 犬
-                      profile_image: 'http://example.com'
-                      status: online
-                      status_message: I'm dog
-                      created_at: '2019-08-24T14:15:22Z'
-                      updated_at: '2019-08-24T14:15:22Z'
-                    - id: 3
-                      username: saru
-                      display_name: 猿
-                      profile_image: 'http://example.com'
-                      status: offline
-                      status_message: I'm monkey
-                      created_at: '2019-08-24T14:15:22Z'
-                      updated_at: '2019-08-24T14:15:22Z'
-                    - id: 4
-                      username: kiji
-                      display_name: 雉
-                      profile_image: 'http://example.com'
-                      status: game
-                      status_message: I'm pheasant
-                      created_at: '2019-08-24T14:15:22Z'
-                      updated_at: '2019-08-24T14:15:22Z'
-        '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      operationId: get-users-userId-friends
-      parameters:
-        - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/offset'
-  /auth/login:
+  '/auth/login':
     get:
       summary: Your GET endpoint
       tags:
@@ -455,7 +398,7 @@ paths:
                 value:
                   username: syudai
                   password: password
-  /auth/callback:
+  '/auth/callback':
     get:
       summary: Your GET endpoint
       tags:
@@ -478,7 +421,196 @@ paths:
         After allowing transcendence on screen 42, you will be redirected here.
         This is where the server-side will register or retrieve the user's information.
       security: []
-    parameters: []
+  '/users/{userID}/followers':
+    parameters:
+      - $ref: '#/components/parameters/userId'
+    get:
+      summary: List Followers of a user
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResponseUser'
+              examples:
+                example:
+                  value:
+                    - id: 2
+                      username: inu
+                      display_name: 犬
+                      profile_image: 'http://example.com'
+                      status: online
+                      status_message: I'm dog
+                      created_at: '2019-08-24T14:15:22Z'
+                      updated_at: '2019-08-24T14:15:22Z'
+                    - id: 3
+                      username: saru
+                      display_name: 猿
+                      profile_image: 'http://example.com'
+                      status: offline
+                      status_message: I'm monkey
+                      created_at: '2019-08-24T14:15:22Z'
+                      updated_at: '2019-08-24T14:15:22Z'
+                    - id: 4
+                      username: kiji
+                      display_name: 雉
+                      profile_image: 'http://example.com'
+                      status: game
+                      status_message: I'm pheasant
+                      created_at: '2019-08-24T14:15:22Z'
+                      updated_at: '2019-08-24T14:15:22Z'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      operationId: get-users-userId-friends
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      tags:
+        - follow
+      description: Lists the people following the specified user.
+  '/users/{userID}/following':
+    parameters:
+      - $ref: '#/components/parameters/userId'
+    get:
+      summary: List the people a user follows
+      tags:
+        - follow
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResponseUser'
+              examples:
+                example:
+                  value:
+                    - id: 1
+                      username: inu
+                      display_name: 犬
+                      status: online
+                      status_message: わん
+                      followers: 1
+                      following: 3
+                      created_at: '2019-08-24T14:15:22Z'
+                      updated_at: '2019-08-24T14:15:22Z'
+                    - id: 2
+                      username: saru
+                      display_name: 猿
+                      status: offline
+                      status_message: うきー
+                      followers: 2
+                      following: 1
+                      created_at: '2019-08-24T14:15:22Z'
+                      updated_at: '2019-08-24T14:15:22Z'
+                    - id: 3
+                      username: kiji
+                      display_name: きじ
+                      status: game
+                      status_message: きー
+                      followers: 2
+                      following: 10
+                      created_at: '2019-08-24T14:15:22Z'
+                      updated_at: '2019-08-24T14:15:22Z'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      operationId: get-users-userID-following
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      description: Lists the people who the specified user follows.
+  '/users/following/{userID}':
+    parameters:
+      - $ref: '#/components/parameters/userId'
+    put:
+      summary: Follow a user
+      operationId: put-users-following-userID
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      tags:
+        - follow
+    delete:
+      summary: Unfollow a user
+      operationId: delete-users-following-userID
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      tags:
+        - follow
+  '/users/{userID}/following/{targetUserID}':
+    parameters:
+      - $ref: '#/components/parameters/userId'
+      - $ref: '#/components/parameters/targetUserID'
+    get:
+      summary: Check if a user follows another user
+      tags:
+        - follow
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      operationId: get-users-userID-following-targetUserID
 components:
   schemas:
     RequestUser:
@@ -533,6 +665,12 @@ components:
             - game
         status_message:
           type: string
+        followers:
+          type: integer
+          minimum: 0
+        following:
+          type: integer
+          minimum: 0
         created_at:
           type: string
           format: date-time
@@ -546,6 +684,8 @@ components:
         - profile_image
         - status
         - status_message
+        - followers
+        - following
         - created_at
         - updated_at
     Error:
@@ -593,6 +733,13 @@ components:
       required: true
       schema:
         type: string
+    targetUserID:
+      name: targetUserID
+      in: path
+      required: true
+      schema:
+        type: integer
+        minimum: 1
   examples: {}
   securitySchemes:
     sessionAuth:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -56,6 +56,10 @@ paths:
                 $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: Internal Server Error
           content:
@@ -102,6 +106,10 @@ paths:
                 $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '409':
           description: Conflict
           content:
@@ -163,6 +171,10 @@ paths:
                 $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: Internal Server Error
           content:
@@ -201,6 +213,10 @@ paths:
                     updated_at: '2019-08-24T14:15:22Z'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Not Found
           content:
@@ -241,6 +257,10 @@ paths:
                     updated_at: '2019-08-24T14:15:22Z'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Not Found
           content:
@@ -272,6 +292,10 @@ paths:
                 $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Not Found
           content:
@@ -316,6 +340,10 @@ paths:
                 $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Not Found
           content:
@@ -487,6 +515,10 @@ paths:
                       updated_at: '2019-08-24T14:15:22Z'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Not Found
           content:
@@ -554,6 +586,10 @@ paths:
                       updated_at: '2019-08-24T14:15:22Z'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Not Found
           content:
@@ -582,6 +618,10 @@ paths:
           description: No Content
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Not Found
           content:
@@ -602,6 +642,10 @@ paths:
       responses:
         '204':
           description: No Content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: Unauthorized
         '404':
@@ -629,8 +673,17 @@ paths:
       responses:
         '204':
           description: No Content
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: ''
         '404':
           description: Not Found
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -88,7 +88,7 @@ paths:
             Set-Cookie:
               schema:
                 type: string
-              description: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
+              description: like SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
         '400':
           description: Bad Request
           content:
@@ -400,7 +400,8 @@ paths:
   /auth/login/42:
     get:
       summary: Your GET endpoint
-      tags: []
+      tags:
+        - auth
       operationId: get-auth-login
       parameters: []
       responses:
@@ -418,7 +419,8 @@ paths:
   /auth/callback/42:
     get:
       summary: Your GET endpoint
-      tags: []
+      tags:
+        - auth
       responses:
         '307':
           description: Temporary Redirect

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -61,8 +61,7 @@ paths:
                 $ref: '#/components/schemas/Error'
       operationId: get-users
       description: ''
-      parameters:
-        - $ref: '#/components/parameters/sessionId'
+      parameters: []
     post:
       summary: Create new user
       operationId: post-users
@@ -88,7 +87,8 @@ paths:
             Set-Cookie:
               schema:
                 type: string
-              description: like SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
+                example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
+              description: set sessionId
         '400':
           description: Bad Request
           content:
@@ -125,8 +125,7 @@ paths:
                   status_message: bow-wow!
       tags:
         - user
-      parameters:
-        - $ref: '#/components/parameters/sessionId'
+      parameters: []
   /me:
     parameters: []
     get:
@@ -165,8 +164,7 @@ paths:
       description: Retrieve the information of the user with the matching user ID.
       tags:
         - user
-      parameters:
-        - $ref: '#/components/parameters/sessionId'
+      parameters: []
   '/users/by/{username}':
     parameters:
       - $ref: '#/components/parameters/username'
@@ -206,8 +204,7 @@ paths:
                 $ref: '#/components/schemas/Error'
       operationId: get-users-username
       description: ''
-      parameters:
-        - $ref: '#/components/parameters/sessionId'
+      parameters: []
   '/users/{userID}':
     parameters:
       - $ref: '#/components/parameters/userId'
@@ -247,8 +244,7 @@ paths:
       description: Retrieve the information of the user with the matching user ID.
       tags:
         - user
-      parameters:
-        - $ref: '#/components/parameters/sessionId'
+      parameters: []
     delete:
       summary: Delete User
       operationId: delete-users-userId
@@ -275,8 +271,7 @@ paths:
                 $ref: '#/components/schemas/Error'
       tags:
         - user
-      parameters:
-        - $ref: '#/components/parameters/sessionId'
+      parameters: []
     put:
       summary: Update User Information
       operationId: put-users-userId
@@ -335,8 +330,7 @@ paths:
                   username: inu
                   display_name: 犬
                   status_message: bow-wow!
-      parameters:
-        - $ref: '#/components/parameters/sessionId'
+      parameters: []
   '/users/{userID}/friends':
     parameters:
       - $ref: '#/components/parameters/userId'
@@ -396,7 +390,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
-        - $ref: '#/components/parameters/sessionId'
   /auth/login/42:
     get:
       summary: Your GET endpoint
@@ -415,6 +408,7 @@ paths:
       description: |-
         The first client request by 42 for oauth2.0.
         After this, you will be redirected to 42's login page.
+      security: []
     parameters: []
   /auth/callback/42:
     get:
@@ -432,12 +426,14 @@ paths:
             Set-Cookie:
               schema:
                 type: string
-              description: like SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
+                example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
+              description: set sessionId
       operationId: get-auth-callback
       description: |-
         After allowing transcendence on screen 42, you will be redirected here.
         This is where the server-side will register or retrieve the user's information.
       parameters: []
+      security: []
     parameters: []
 components:
   schemas:
@@ -547,11 +543,12 @@ components:
       schema:
         type: integer
         minimum: 0
-    sessionId:
-      name: sessionId
-      in: cookie
-      required: true
-      schema:
-        type: string
   examples: {}
-  securitySchemes: {}
+  securitySchemes:
+    sessionAuth:
+      name: sessionId
+      type: apiKey
+      in: cookie
+      description: sessionId needed in cookie
+security:
+  - sessionAuth: []

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -434,7 +434,27 @@ paths:
         content:
           application/json:
             schema:
+              description: ''
               type: object
+              properties:
+                username:
+                  type: string
+                  minLength: 1
+                password:
+                  type: string
+                  minLength: 1
+              required:
+                - username
+                - password
+              x-examples:
+                example-1:
+                  username: syudai
+                  password: magiimine
+            examples:
+              example-1:
+                value:
+                  username: syudai
+                  password: password
   /auth/callback:
     get:
       summary: Your GET endpoint

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -347,12 +347,7 @@ paths:
             Location:
               schema:
                 type: string
-              description: browser confirm of 42
-          content:
-            application/json:
-              schema:
-                type: object
-                properties: {}
+              description: redirect to 42's confirm browser
         '500':
           description: Internal Server Error
       description: |-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -61,6 +61,7 @@ paths:
                 $ref: '#/components/schemas/Error'
       operationId: get-users
       description: ''
+      parameters: []
     post:
       summary: Create new user
       operationId: post-users
@@ -124,7 +125,9 @@ paths:
                   status_message: bow-wow!
       tags:
         - user
+      parameters: []
   /me:
+    parameters: []
     get:
       summary: Get User Info by User ID
       responses:
@@ -161,6 +164,7 @@ paths:
       description: Retrieve the information of the user with the matching user ID.
       tags:
         - user
+      parameters: []
   '/users/by/{username}':
     parameters:
       - $ref: '#/components/parameters/username'
@@ -200,6 +204,7 @@ paths:
                 $ref: '#/components/schemas/Error'
       operationId: get-users-username
       description: ''
+      parameters: []
   '/users/{userID}':
     parameters:
       - $ref: '#/components/parameters/userId'
@@ -239,6 +244,7 @@ paths:
       description: Retrieve the information of the user with the matching user ID.
       tags:
         - user
+      parameters: []
     delete:
       summary: Delete User
       operationId: delete-users-userId
@@ -265,6 +271,7 @@ paths:
                 $ref: '#/components/schemas/Error'
       tags:
         - user
+      parameters: []
     put:
       summary: Update User Information
       operationId: put-users-userId
@@ -323,6 +330,7 @@ paths:
                   username: inu
                   display_name: 犬
                   status_message: bow-wow!
+      parameters: []
   '/users/{userID}/friends':
     parameters:
       - $ref: '#/components/parameters/userId'
@@ -382,12 +390,13 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
-  /auth/login/42:
+  '/auth/login/{provider}':
     get:
       summary: Your GET endpoint
       tags:
         - auth
       operationId: get-auth-login
+      parameters: []
       responses:
         '307':
           description: Temporary Redirect
@@ -402,9 +411,15 @@ paths:
                 example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
               description: set sessionId in cookie
       description: |-
-        The first client request by 42 for oauth2.0.
-        After this, you will be redirected to 42's login page.
+        The first client request by provider for oauth2.0.
+        After this, you will be redirected to provider's login page.
       security: []
+    parameters:
+      - schema:
+          type: string
+        name: provider
+        in: path
+        required: true
 components:
   schemas:
     RequestUser:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -339,8 +339,7 @@ paths:
       tags:
         - auth
       operationId: get-auth-login
-      parameters:
-        - $ref: '#/components/parameters/provider'
+      parameters: []
       responses:
         '307':
           description: Temporary Redirect
@@ -349,6 +348,13 @@ paths:
               schema:
                 type: string
               description: browser confirm of 42
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+        '500':
+          description: Internal Server Error
       description: |-
         The first client request by 42 for oauth2.0.
         After this, you will be redirected to 42's confirm browser.
@@ -370,6 +376,10 @@ paths:
                 type: string
                 example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
               description: set sessionId
+        '400':
+          description: Bad Request
+        '500':
+          description: Internal Server Error
       description: username and password auth without using auth.
       parameters: []
       security: []
@@ -377,7 +387,22 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SimpleLoginUser'
+              description: ''
+              type: object
+              properties:
+                username:
+                  type: string
+                  minLength: 1
+                password:
+                  type: string
+                  minLength: 1
+              required:
+                - username
+                - password
+              x-examples:
+                example-1:
+                  username: syudai
+                  password: password
             examples:
               example-1:
                 value:
@@ -403,6 +428,8 @@ paths:
                 type: string
                 example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
               description: set sessionId
+        '500':
+          description: Internal Server Error
       operationId: get-auth-callback
       description: |-
         After allowing transcendence on screen 42, you will be redirected here.
@@ -683,20 +710,6 @@ components:
           type: integer
         mesasge:
           type: string
-    SimpleLoginUser:
-      description: ''
-      type: object
-      x-examples:
-        example-1:
-          username: syudai
-          password: abc
-      properties:
-        username:
-          type: string
-          minLength: 1
-        password:
-          type: string
-          minLength: 1
   requestBodies: {}
   responses: {}
   parameters:
@@ -728,12 +741,6 @@ components:
       schema:
         type: integer
         minimum: 0
-    provider:
-      name: provider
-      in: query
-      required: true
-      schema:
-        type: string
     targetUserID:
       name: targetUserID
       in: path


### PR DESCRIPTION
## チケットへのリンク
#7 

## やったこと
42 oauthで必要なAPI追加(/auth/login/42, /auth/callback/42)
Set-CookieやLocationなど必要なヘッダ追加

## やらないこと

## テスト
docsなので目視

## その他
Set-Cookieの説明でSecure属性をつけてますが、開発の際はつけないです。(dev中はhttps化してないため)
/auth/login/42 ... 下の画像の(1)
/auth/callback/42 ... 下の画像の(5)
![image](https://user-images.githubusercontent.com/66932739/151666488-de792e7e-f7bf-45ce-81c4-783d88566c19.png)

 
全体のイメージの参考: https://github.com/sasakiyudai/websocket-chat
