### PR TITLE
ResponseUserのfollowers/followingをオプショナルに変更

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -860,8 +860,6 @@ components:
         - profile_image
         - status
         - status_message
-        - followers
-        - following
         - created_at
         - updated_at
     Error:


### PR DESCRIPTION
## チケットへのリンク
https://github.com/RIFT-tokyo/transcendence-api/issues/15
## やったこと
ResponseUserのfollowers/followingをoptionalなパラメータに変更しました。
`GET /users/:id/following`, `GET /users/:id/followers` で無駄にクエリが増えてしまうのを避けるためにオプショナルにしました。
## やらないこと

## テスト

## その他
