### PR TITLE
ユーザー作成・Schema変更

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23,7 +23,7 @@ paths:
                 type: string
               description: redirect to 42's confirm browser
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       description: |-
         The first client request by 42 for oauth2.0.
         After this, you will be redirected to 42's confirm browser.
@@ -46,9 +46,9 @@ paths:
                 example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
               description: set sessionId
         '400':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/400-Bad-Request'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       description: username and password auth without using auth.
       parameters: []
       security: []
@@ -64,13 +64,11 @@ paths:
         '200':
           $ref: '#/components/responses/User'
         '400':
-          $ref: '#/components/responses/Error'
-        '401':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/400-Bad-Request'
         '409':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/409-Conflict'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       requestBody:
         $ref: '#/components/requestBodies/Login'
       parameters: []
@@ -96,7 +94,7 @@ paths:
                 example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
               description: set sessionId
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       operationId: get-auth-callback
       description: |-
         After allowing transcendence on screen 42, you will be redirected here.
@@ -110,11 +108,11 @@ paths:
         '200':
           $ref: '#/components/responses/User'
         '400':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/400-Bad-Request'
         '401':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/401-Unauthorized'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       operationId: get-me
       description: Retrieve the information of the user with the matching user ID.
       tags:
@@ -129,11 +127,11 @@ paths:
         '200':
           $ref: '#/components/responses/UserList'
         '400':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/400-Bad-Request'
         '401':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/401-Unauthorized'
         '500':
-          $ref: '#/components/responses/User'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       operationId: get-users
       description: ''
       parameters:
@@ -150,11 +148,11 @@ paths:
         '200':
           $ref: '#/components/responses/User'
         '401':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/401-Unauthorized'
         '404':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/404-Not-Found'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       operationId: get-users-username
       description: ''
       parameters: []
@@ -167,11 +165,11 @@ paths:
         '200':
           $ref: '#/components/responses/User'
         '401':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/401-Unauthorized'
         '404':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/404-Not-Found'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       operationId: get-users-userId
       description: Retrieve the information of the user with the matching user ID.
       tags:
@@ -184,13 +182,13 @@ paths:
         '204':
           description: No Content
         '400':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/400-Bad-Request'
         '401':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/401-Unauthorized'
         '404':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/404-Not-Found'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       tags:
         - user
       parameters: []
@@ -201,15 +199,15 @@ paths:
         '200':
           $ref: '#/components/responses/User'
         '400':
-          $ref: '#/components/responses/User'
+          $ref: '#/components/responses/400-Bad-Request'
         '401':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/401-Unauthorized'
         '404':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/404-Not-Found'
         '409':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/409-Conflict'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       tags:
         - user
       requestBody:
@@ -224,15 +222,15 @@ paths:
         '204':
           description: No Content
         '401':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/401-Unauthorized'
         '404':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/404-Not-Found'
         '413':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/413-Payload-Too-Large'
         '415':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/415-Unsupported-Media-Type'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       description: ''
       requestBody:
         content:
@@ -249,11 +247,11 @@ paths:
         '204':
           description: No Content
         '401':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/401-Unauthorized'
         '404':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/404-Not-Found'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       description: ''
       tags:
         - user
@@ -266,11 +264,11 @@ paths:
         '200':
           $ref: '#/components/responses/UserList'
         '401':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/401-Unauthorized'
         '404':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/404-Not-Found'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       operationId: get-users-userId-friends
       parameters:
         - $ref: '#/components/parameters/limit'
@@ -289,11 +287,11 @@ paths:
         '200':
           $ref: '#/components/responses/UserList'
         '401':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/401-Unauthorized'
         '404':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/404-Not-Found'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       operationId: get-users-userID-following
       parameters:
         - $ref: '#/components/parameters/limit'
@@ -309,13 +307,11 @@ paths:
         '204':
           description: No Content
         '401':
-          $ref: '#/components/responses/Error'
-        '403':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/401-Unauthorized'
         '404':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/404-Not-Found'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       tags:
         - follow
       description: ''
@@ -326,11 +322,11 @@ paths:
         '204':
           description: No Content
         '401':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/401-Unauthorized'
         '404':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/404-Not-Found'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       tags:
         - follow
   '/users/{userID}/following/{targetUserID}':
@@ -345,11 +341,11 @@ paths:
         '204':
           description: No Content
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+          $ref: '#/components/responses/401-Unauthorized'
         '404':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/404-Not-Found'
         '500':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/500-Internal-Server-Error'
       operationId: get-users-userID-following-targetUserID
 components:
   schemas:
@@ -438,23 +434,8 @@ components:
                 username: tstark
                 password: password
   responses:
-    Error:
-      description: Error response
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
-          examples:
-            '400':
-              value:
-                status_code: 400
-                message: Bad Request
-            '500':
-              value:
-                status_code: 500
-                message: Internal Server Error
     User:
-      description: Response a user
+      description: User response
       content:
         application/json:
           schema:
@@ -473,7 +454,7 @@ components:
                 created_at: '2019-08-24T14:15:22Z'
                 updated_at: '2019-08-24T14:15:22Z'
     UserList:
-      description: Example response
+      description: User list response
       content:
         application/json:
           schema:
@@ -513,6 +494,83 @@ components:
                   following: 1
                   created_at: '2019-08-24T14:15:22Z'
                   updated_at: '2019-08-24T14:15:22Z'
+    400-Bad-Request:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            example:
+              value:
+                status_code: 400
+                message: Bad Request
+    401-Unauthorized:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            example:
+              value:
+                status_code: 401
+                message: Unauthorized
+    404-Not-Found:
+      description: Error response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            '404':
+              value:
+                status_code: 404
+                message: Not Found
+    409-Conflict:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            example:
+              value:
+                status_code: 409
+                message: Conflict
+    413-Payload-Too-Large:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            example:
+              value:
+                status_code: 413
+                message: Payload Too Large
+    415-Unsupported-Media-Type:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            example:
+              value:
+                status_code: 415
+                message: Unsupported Media Type
+    500-Internal-Server-Error:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            example:
+              value:
+                status_code: 500
+                message: Internal Server Error
   parameters:
     userId:
       name: userID

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -130,7 +130,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResponseUser'
+                $ref: '#/components/schemas/User'
               examples:
                 example:
                   value:
@@ -178,7 +178,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ResponseUser'
+                  $ref: '#/components/schemas/User'
               examples:
                 example:
                   value:
@@ -312,7 +312,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResponseUser'
+                $ref: '#/components/schemas/User'
               examples:
                 example:
                   value:
@@ -433,7 +433,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResponseUser'
+                $ref: '#/components/schemas/User'
               examples:
                 example:
                   value:
@@ -481,7 +481,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RequestUser'
+              $ref: '#/components/schemas/User'
             examples:
               example:
                 value:
@@ -576,7 +576,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ResponseUser'
+                  $ref: '#/components/schemas/User'
               examples:
                 example:
                   value:
@@ -644,7 +644,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ResponseUser'
+                  $ref: '#/components/schemas/User'
               examples:
                 example:
                   value:
@@ -765,17 +765,12 @@ paths:
       responses:
         '204':
           description: No Content
-          content:
-            application/json:
-              schema:
-                type: object
-                properties: {}
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                $ref: ''
+                $ref: '#/components/schemas/Error'
         '404':
           description: Not Found
           content:
@@ -791,24 +786,19 @@ paths:
       operationId: get-users-userID-following-targetUserID
 components:
   schemas:
-    RequestUser:
-      title: RequestUser
+    Login:
+      title: Login
       type: object
-      x-examples:
-        example:
-          username: bunjiro
-          display_name: 文次郎
-          status_message: Don't Panic!
       properties:
         username:
           type: string
-          minLength: 1
-        display_name:
+        password:
           type: string
-        status_message:
-          type: string
-    ResponseUser:
-      title: ResponseUser
+      required:
+        - username
+        - password
+    User:
+      title: User
       type: object
       x-examples:
         example:
@@ -853,15 +843,6 @@ components:
         updated_at:
           type: string
           format: date-time
-      required:
-        - id
-        - username
-        - display_name
-        - profile_image
-        - status
-        - status_message
-        - created_at
-        - updated_at
     Error:
       title: Error
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -68,22 +68,7 @@ paths:
         content:
           application/json:
             schema:
-              description: ''
-              type: object
-              properties:
-                username:
-                  type: string
-                  minLength: 1
-                password:
-                  type: string
-                  minLength: 1
-              required:
-                - username
-                - password
-              x-examples:
-                example-1:
-                  username: syudai
-                  password: password
+              $ref: '#/components/schemas/Login'
             examples:
               example-1:
                 value:
@@ -91,6 +76,77 @@ paths:
                   password: password
       tags:
         - auth
+  /auth/signup:
+    post:
+      summary: Create new user
+      operationId: post-users
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+              examples:
+                example:
+                  value:
+                    id: 1
+                    username: taro
+                    display_name: 太郎
+                    profile_image: 'http://example.com'
+                    status: online
+                    status_message: ほげほげ
+                    created_at: '2019-08-24T14:15:22Z'
+                    updated_at: '2019-08-24T14:15:22Z'
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+                example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
+              description: set sessionId
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                example:
+                  value:
+                    status_code: 409
+                    message: username is already used
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Login'
+            examples:
+              example:
+                value:
+                  username: john
+                  password: P@ssw0rd
+      parameters: []
+      tags:
+        - auth
+      security: []
   /auth/callback:
     get:
       summary: Oauth callback
@@ -229,76 +285,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
-    post:
-      summary: Create new user
-      operationId: post-users
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseUser'
-              examples:
-                example:
-                  value:
-                    id: 1
-                    username: taro
-                    display_name: 太郎
-                    profile_image: 'http://example.com'
-                    status: online
-                    status_message: ほげほげ
-                    created_at: '2019-08-24T14:15:22Z'
-                    updated_at: '2019-08-24T14:15:22Z'
-          headers:
-            Set-Cookie:
-              schema:
-                type: string
-                example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
-              description: set sessionId
-        '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '409':
-          description: Conflict
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                example:
-                  value:
-                    status_code: 409
-                    message: username is already used
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RequestUser'
-            examples:
-              example:
-                value:
-                  username: inu
-                  display_name: 犬
-                  status_message: bow-wow!
-      tags:
-        - user
-      parameters: []
   '/users/by/{username}':
     parameters:
       - $ref: '#/components/parameters/username'
@@ -356,7 +342,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResponseUser'
+                $ref: '#/components/schemas/User'
               examples:
                 example:
                   value:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -33,13 +33,9 @@ paths:
       summary: username and password login
       operationId: post-auth-login
       responses:
-        '307':
-          description: Temporary Redirect
+        '204':
+          description: No Content
           headers:
-            Location:
-              schema:
-                type: string
-              description: to the home
             Set-Cookie:
               schema:
                 type: string
@@ -61,13 +57,9 @@ paths:
       summary: Create new user
       operationId: post-users
       responses:
-        '307':
-          description: Temporary Redirect
+        '204':
+          description: No Content
           headers:
-            Location:
-              schema:
-                type: string
-              description: to the home
             Set-Cookie:
               schema:
                 type: string
@@ -90,13 +82,9 @@ paths:
       tags:
         - auth
       responses:
-        '307':
-          description: Temporary Redirect
+        '204':
+          description: No Content
           headers:
-            Location:
-              schema:
-                type: string
-              description: to the home
             Set-Cookie:
               schema:
                 type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23,11 +23,7 @@ paths:
                 type: string
               description: redirect to 42's confirm browser
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       description: |-
         The first client request by 42 for oauth2.0.
         After this, you will be redirected to 42's confirm browser.
@@ -50,99 +46,33 @@ paths:
                 example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
               description: set sessionId
         '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       description: username and password auth without using auth.
       parameters: []
       security: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Login'
-            examples:
-              example-1:
-                value:
-                  username: syudai
-                  password: password
       tags:
         - auth
+      requestBody:
+        $ref: '#/components/requestBodies/Login'
   /auth/signup:
     post:
       summary: Create new user
       operationId: post-users
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-              examples:
-                example:
-                  value:
-                    id: 1
-                    username: taro
-                    display_name: 太郎
-                    profile_image: 'http://example.com'
-                    status: online
-                    status_message: ほげほげ
-                    created_at: '2019-08-24T14:15:22Z'
-                    updated_at: '2019-08-24T14:15:22Z'
-          headers:
-            Set-Cookie:
-              schema:
-                type: string
-                example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
-              description: set sessionId
+          $ref: '#/components/responses/User'
         '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '409':
-          description: Conflict
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                example:
-                  value:
-                    status_code: 409
-                    message: username is already used
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Login'
-            examples:
-              example:
-                value:
-                  username: john
-                  password: P@ssw0rd
+        $ref: '#/components/requestBodies/Login'
       parameters: []
       tags:
         - auth
@@ -166,11 +96,7 @@ paths:
                 example: SessionID=CA978112CA1BBDCAFAC231B39A23DC4DA; Path=/; Secure; HttpOnly
               description: set sessionId
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       operationId: get-auth-callback
       description: |-
         After allowing transcendence on screen 42, you will be redirected here.
@@ -182,40 +108,13 @@ paths:
       summary: Get the authenticated user
       responses:
         '200':
-          description: User Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-              examples:
-                example:
-                  value:
-                    id: 1
-                    username: taro
-                    display_name: 太郎
-                    profile_image: 'http://example.com'
-                    status: online
-                    status_message: ほげほげ
-                    created_at: '2019-08-24T14:15:22Z'
-                    updated_at: '2019-08-24T14:15:22Z'
+          $ref: '#/components/responses/User'
         '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       operationId: get-me
       description: Retrieve the information of the user with the matching user ID.
       tags:
@@ -228,58 +127,13 @@ paths:
         - user
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/User'
-              examples:
-                example:
-                  value:
-                    - id: 1
-                      username: inu
-                      display_name: 犬
-                      profile_image: 'http://example.com'
-                      status: online
-                      status_message: I'm dog
-                      created_at: '2019-08-24T14:15:22Z'
-                      updated_at: '2019-08-24T14:15:22Z'
-                    - id: 2
-                      username: saru
-                      display_name: 猿
-                      profile_image: 'http://example.com'
-                      status: offline
-                      status_message: I'm monkey
-                      created_at: '2019-08-24T14:15:22Z'
-                      updated_at: '2019-08-24T14:15:22Z'
-                    - id: 3
-                      username: kiji
-                      display_name: 雉
-                      profile_image: 'http://example.com'
-                      status: game
-                      status_message: I'm pheasant
-                      created_at: '2019-08-24T14:15:22Z'
-                      updated_at: '2019-08-24T14:15:22Z'
+          $ref: '#/components/responses/UserList'
         '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/User'
       operationId: get-users
       description: ''
       parameters:
@@ -294,40 +148,13 @@ paths:
         - user
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-              examples:
-                example:
-                  value:
-                    id: 1
-                    username: taro
-                    display_name: 太郎
-                    profile_image: 'http://example.com'
-                    status: online
-                    status_message: ほげほげ
-                    created_at: '2019-08-24T14:15:22Z'
-                    updated_at: '2019-08-24T14:15:22Z'
+          $ref: '#/components/responses/User'
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       operationId: get-users-username
       description: ''
       parameters: []
@@ -338,40 +165,13 @@ paths:
       summary: Get a user
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-              examples:
-                example:
-                  value:
-                    id: 1
-                    username: taro
-                    display_name: 太郎
-                    profile_image: 'http://example.com'
-                    status: online
-                    status_message: ほげほげ
-                    created_at: '2019-08-24T14:15:22Z'
-                    updated_at: '2019-08-24T14:15:22Z'
+          $ref: '#/components/responses/User'
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       operationId: get-users-userId
       description: Retrieve the information of the user with the matching user ID.
       tags:
@@ -384,29 +184,13 @@ paths:
         '204':
           description: No Content
         '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       tags:
         - user
       parameters: []
@@ -415,65 +199,21 @@ paths:
       operationId: put-users-userId
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-              examples:
-                example:
-                  value:
-                    id: 1
-                    username: taro
-                    display_name: 太郎
-                    profile_image: 'http://example.com'
-                    status: online
-                    status_message: ほげほげ
-                    created_at: '2019-08-24T14:15:22Z'
-                    updated_at: '2019-08-24T14:15:22Z'
+          $ref: '#/components/responses/User'
         '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/User'
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '409':
-          description: Conflict
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       tags:
         - user
       requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/User'
-            examples:
-              example:
-                value:
-                  username: inu
-                  display_name: 犬
-                  status_message: bow-wow!
+        $ref: '#/components/requestBodies/User'
   '/users/{userID}/images':
     parameters:
       - $ref: '#/components/parameters/userId'
@@ -484,35 +224,15 @@ paths:
         '204':
           description: No Content
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '413':
-          description: Request Entity Too Large
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '415':
-          description: Unsupported Media Type
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       description: ''
       requestBody:
         content:
@@ -529,23 +249,11 @@ paths:
         '204':
           description: No Content
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       description: ''
       tags:
         - user
@@ -556,58 +264,13 @@ paths:
       summary: List Followers of a user
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/User'
-              examples:
-                example:
-                  value:
-                    - id: 2
-                      username: inu
-                      display_name: 犬
-                      profile_image: 'http://example.com'
-                      status: online
-                      status_message: I'm dog
-                      created_at: '2019-08-24T14:15:22Z'
-                      updated_at: '2019-08-24T14:15:22Z'
-                    - id: 3
-                      username: saru
-                      display_name: 猿
-                      profile_image: 'http://example.com'
-                      status: offline
-                      status_message: I'm monkey
-                      created_at: '2019-08-24T14:15:22Z'
-                      updated_at: '2019-08-24T14:15:22Z'
-                    - id: 4
-                      username: kiji
-                      display_name: 雉
-                      profile_image: 'http://example.com'
-                      status: game
-                      status_message: I'm pheasant
-                      created_at: '2019-08-24T14:15:22Z'
-                      updated_at: '2019-08-24T14:15:22Z'
+          $ref: '#/components/responses/UserList'
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       operationId: get-users-userId-friends
       parameters:
         - $ref: '#/components/parameters/limit'
@@ -624,61 +287,13 @@ paths:
         - follow
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/User'
-              examples:
-                example:
-                  value:
-                    - id: 1
-                      username: inu
-                      display_name: 犬
-                      status: online
-                      status_message: わん
-                      followers: 1
-                      following: 3
-                      created_at: '2019-08-24T14:15:22Z'
-                      updated_at: '2019-08-24T14:15:22Z'
-                    - id: 2
-                      username: saru
-                      display_name: 猿
-                      status: offline
-                      status_message: うきー
-                      followers: 2
-                      following: 1
-                      created_at: '2019-08-24T14:15:22Z'
-                      updated_at: '2019-08-24T14:15:22Z'
-                    - id: 3
-                      username: kiji
-                      display_name: きじ
-                      status: game
-                      status_message: きー
-                      followers: 2
-                      following: 10
-                      created_at: '2019-08-24T14:15:22Z'
-                      updated_at: '2019-08-24T14:15:22Z'
+          $ref: '#/components/responses/UserList'
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       operationId: get-users-userID-following
       parameters:
         - $ref: '#/components/parameters/limit'
@@ -694,23 +309,13 @@ paths:
         '204':
           description: No Content
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
+        '403':
+          $ref: '#/components/responses/Error'
         '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       tags:
         - follow
       description: ''
@@ -720,24 +325,12 @@ paths:
       responses:
         '204':
           description: No Content
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized
+          $ref: '#/components/responses/Error'
         '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       tags:
         - follow
   '/users/{userID}/following/{targetUserID}':
@@ -752,50 +345,17 @@ paths:
         '204':
           description: No Content
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/ErrorResponse'
         '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
         '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/Error'
       operationId: get-users-userID-following-targetUserID
 components:
   schemas:
-    Login:
-      title: Login
-      type: object
-      properties:
-        username:
-          type: string
-        password:
-          type: string
-      required:
-        - username
-        - password
     User:
       title: User
       type: object
-      x-examples:
-        example:
-          id: 42
-          username: nop
-          display_name: のっぷ
-          profile_image: 'localost:4211/users/nop/profile.jpg'
-          status: online
-          status_message: May the force be with you.
-          created_at: '2021-01-01T12:42:42Z'
-          updated_at: '2042-01-01T12:42:42Z'
       properties:
         id:
           type: integer
@@ -829,16 +389,130 @@ components:
         updated_at:
           type: string
           format: date-time
+    Login:
+      title: Login
+      type: object
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+      required:
+        - username
+        - password
     Error:
       title: Error
       type: object
       properties:
         status_code:
           type: integer
-        mesasge:
+        message:
           type: string
-  requestBodies: {}
-  responses: {}
+  requestBodies:
+    User:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/User'
+          examples:
+            example:
+              value:
+                display_name: Ironman
+                status_message: I love you 3000.
+    Login:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              username:
+                type: string
+              password:
+                type: string
+            required:
+              - username
+              - password
+          examples:
+            example:
+              value:
+                username: tstark
+                password: password
+  responses:
+    Error:
+      description: Error response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          examples:
+            '400':
+              value:
+                status_code: 400
+                message: Bad Request
+            '500':
+              value:
+                status_code: 500
+                message: Internal Server Error
+    User:
+      description: Response a user
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/User'
+          examples:
+            example:
+              value:
+                id: 512
+                username: tstark
+                display_name: Tony Stark
+                profile_image: 'http://cdn.transcendence.com/profile/tstark.jpg'
+                status: online
+                status_message: I am Ironman.
+                followers: 3000
+                following: 85
+                created_at: '2019-08-24T14:15:22Z'
+                updated_at: '2019-08-24T14:15:22Z'
+    UserList:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+          examples:
+            example:
+              value:
+                - id: 512
+                  username: tstark
+                  display_name: Tony Stark
+                  profile_image: 'http://cdn.transcendence.com/profile/tstark.jpg'
+                  status: online
+                  status_message: I am Ironman.
+                  followers: 3000
+                  following: 85
+                  created_at: '2019-08-24T14:15:22Z'
+                  updated_at: '2019-08-24T14:15:22Z'
+                - id: 412
+                  username: pparker
+                  display_name: Peter Parker
+                  profile_image: 'http://cdn.transcendence.com/profile/pparker.jpg'
+                  status: online
+                  status_message: Great power comes with great responsibility
+                  followers: 625
+                  following: 42
+                  created_at: '2019-08-24T14:15:22Z'
+                  updated_at: '2019-08-24T14:15:22Z'
+                - id: 381
+                  username: srogers
+                  display_name: Steve Rogers
+                  profile_image: 'http://cdn.transcendence.com/profile/srogers.jpg'
+                  status: online
+                  status_message: The Sentinel of Liberty
+                  followers: 1918
+                  following: 1
+                  created_at: '2019-08-24T14:15:22Z'
+                  updated_at: '2019-08-24T14:15:22Z'
   parameters:
     userId:
       name: userID

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -61,8 +61,17 @@ paths:
       summary: Create new user
       operationId: post-users
       responses:
-        '200':
-          $ref: '#/components/responses/User'
+        '307':
+          description: Temporary Redirect
+          headers:
+            Location:
+              schema:
+                type: string
+              description: to the home
+            Set-Cookie:
+              schema:
+                type: string
+              description: set sessionId
         '400':
           $ref: '#/components/responses/400-Bad-Request'
         '409':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -515,7 +515,7 @@ components:
                 status_code: 400
                 message: Bad Request
     401-Unauthorized:
-      description: Example response
+      description: Unauthorized
       content:
         application/json:
           schema:
@@ -526,7 +526,7 @@ components:
                 status_code: 401
                 message: Unauthorized
     404-Not-Found:
-      description: Error response
+      description: Not Found
       content:
         application/json:
           schema:
@@ -537,7 +537,7 @@ components:
                 status_code: 404
                 message: Not Found
     409-Conflict:
-      description: Example response
+      description: Conflict
       content:
         application/json:
           schema:
@@ -548,7 +548,7 @@ components:
                 status_code: 409
                 message: Conflict
     413-Payload-Too-Large:
-      description: Example response
+      description: Payload Too Large
       content:
         application/json:
           schema:
@@ -559,7 +559,7 @@ components:
                 status_code: 413
                 message: Payload Too Large
     415-Unsupported-Media-Type:
-      description: Example response
+      description: Unsupported Media Type
       content:
         application/json:
           schema:
@@ -570,7 +570,7 @@ components:
                 status_code: 415
                 message: Unsupported Media Type
     500-Internal-Server-Error:
-      description: Example response
+      description: Internal Server Error
       content:
         application/json:
           schema:


### PR DESCRIPTION
## チケットへのリンク
https://github.com/orgs/RIFT-tokyo/projects/1#card-77958236
https://github.com/orgs/RIFT-tokyo/projects/1#card-77844703

## やったこと
### Schema変更
- ResponseUser, RequestUserを廃止し、Userに統一
- Login Schemaを作成
### ユーザー作成のendpointの追加
- POST /usersをPOST /auth/signupに変更
- 作成したら認証したらリダイレクトを返すように修正
### Response, Request BodiesのSchema作成
- Request BodiesにLogin, Userを作成
- ResponseにUser, UserList, 各ステータスコードごとのエラーを作成
これにより、各エンドポイントの定義が簡単になりました。ここからのエンドポイントの定義はこれらを使うか新たにRequest Bodies, Response Schemaを作成してください。

## やらないこと

## テスト

## その他
自動生成のコードもfront, api共に一通り目を通しましたが、特に問題はなさそうでした。
このPRが承認されたら、front, apiのリポジトリでopenapiから自動生成したコードを各mainブランチにコミットしようと思います。