### PR TITLE
logoutエンドポイントの追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9,7 +9,7 @@ servers:
 paths:
   /auth/login:
     get:
-      summary: Oauth login request
+      summary: Login with 42 intra account
       tags:
         - auth
       operationId: get-auth-login
@@ -30,7 +30,7 @@ paths:
       security: []
     parameters: []
     post:
-      summary: username and password login
+      summary: Login with username and password
       operationId: post-auth-login
       responses:
         '204':
@@ -52,6 +52,21 @@ paths:
         - auth
       requestBody:
         $ref: '#/components/requestBodies/Login'
+  /auth/logout:
+    get:
+      summary: Logout from transcendence
+      operationId: post-auth-logout
+      responses:
+        '204':
+          description: No Content
+          headers: {}
+        '401':
+          $ref: '#/components/responses/401-Unauthorized'
+        '500':
+          $ref: '#/components/responses/500-Internal-Server-Error'
+      tags:
+        - auth
+      description: logout from transcendence
   /auth/signup:
     post:
       summary: Create new user
@@ -82,8 +97,8 @@ paths:
       tags:
         - auth
       responses:
-        '204':
-          description: No Content
+        '302':
+          description: Found
           headers:
             Set-Cookie:
               schema:


### PR DESCRIPTION
## チケットへのリンク
https://github.com/orgs/RIFT-tokyo/projects/1#card-77959117
## やったこと
### ログアウト用のエンドポイントを追加しました。
認証済みのユーザーがこのエンドポイントを叩く必要があるため、authタグのエンドポイントで唯一認証つきのエンドポイントにしています。
成功すると、セッションに含まれるuserIDをnullにする予定です。
### intra認証のcallbackに対するレスポンスをリダイレクトに変更
apiサーバからfrontに遷移する必要があるため、204ではなくリダイレクトにしました。
## やらないこと

## テスト

## その他
